### PR TITLE
Be informed when the list view is displayed/dismissed

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -129,21 +129,8 @@ export default class GooglePlacesAutocomplete extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    let listViewDisplayed = true;
-
-    if (nextProps.listViewDisplayed !== 'auto') {
-      listViewDisplayed = nextProps.listViewDisplayed;
-    }
-
-    if (typeof (nextProps.text) !== "undefined" && this.state.text !== nextProps.text) {
-      this.setState({
-          listViewDisplayed: listViewDisplayed
-        },
-        this._handleChangeText(nextProps.text));
-    } else {
-      this.setState({
-        listViewDisplayed: listViewDisplayed
-      });
+    if (nextProps.text !== undefined && this.state.text !== nextProps.text) {
+      this._handleChangeText(nextProps.text)
     }
   }
 
@@ -516,10 +503,8 @@ export default class GooglePlacesAutocomplete extends Component {
   _onChangeText = (text) => {
     this._request(text);
 
-    this.setState({
-      text: text,
-      listViewDisplayed: this._isMounted || this.props.autoFocus,
-    });
+    this.setState({ text });
+    this._setListViewDisplayed(this._isMounted || this.props.autoFocus);
   }
 
   _handleChangeText = (text) => {
@@ -531,6 +516,16 @@ export default class GooglePlacesAutocomplete extends Component {
 
     if (onChangeText) {
       onChangeText(text);
+    }
+  }
+
+  _setListViewDisplayed(isDisplayed) {
+    if (this.state.listViewDisplayed === isDisplayed) return;
+
+    this.setState({ listViewDisplayed: isDisplayed });
+
+    if (typeof this.props.onListViewDisplayed === "function") {
+      this.props.onListViewDisplayed(isDisplayed);
     }
   }
 
@@ -614,13 +609,12 @@ export default class GooglePlacesAutocomplete extends Component {
 
   _onBlur = () => {
     this.triggerBlur();
-
-    this.setState({
-      listViewDisplayed: false
-    });
+    this._setListViewDisplayed(false);
   }
 
-  _onFocus = () => this.setState({ listViewDisplayed: true })
+  _onFocus = () => {
+    this._setListViewDisplayed(true);
+  }
 
   _renderPoweredLogo = () => {
     if (!this._shouldShowPoweredLogo()) {


### PR DESCRIPTION
Our parent view would like to know whether or not the list view is being displayed so that it can hide sibling views and avoid components jumping around. To do this, I've added a callback `onListViewDisplayed(isDisplayed: boolean)` which allows the parent to make these changes to its state.

I've removed the logic from `componentWillReceiveProps` related to `listViewDisplayed` since this component fully owns this state. The prop is only used on initialization.