### PR TITLE
Restricting autocomplete fields to basic fields

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -283,6 +283,7 @@ export default class GooglePlacesAutocomplete extends Component {
         key: this.props.query.key,
         placeid: rowData.place_id,
         language: this.props.query.language,
+        fields: this.props.autocompleteFields,
       }));
 
       if (this.props.query.origin !== null) {
@@ -766,7 +767,8 @@ GooglePlacesAutocomplete.propTypes = {
   suppressDefaultStyles: PropTypes.bool,
   numberOfLines: PropTypes.number,
   onSubmitEditing: PropTypes.func,
-  editable: PropTypes.bool
+  editable: PropTypes.bool,
+  fields: PropTypes.string
 }
 GooglePlacesAutocomplete.defaultProps = {
   placeholder: 'Search',
@@ -812,7 +814,8 @@ GooglePlacesAutocomplete.defaultProps = {
   suppressDefaultStyles: false,
   numberOfLines: 1,
   onSubmitEditing: () => {},
-  editable: true
+  editable: true,
+  autocompleteFields: 'geometry,type'
 }
 
 // this function is still present in the library to be retrocompatible with version < 1.1.0

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ const GooglePlacesInput = () => {
       minLength={2} // minimum length of text to search
       autoFocus={false}
       returnKeyType={'search'} // Can be left out for default return key https://facebook.github.io/react-native/docs/textinput.html#returnkeytype
+      autocompleteFields={'geometry,url'} // Specific fields being requested https://developers.google.com/places/web-service/details#fields
       listViewDisplayed='auto'    // true/false/undefined
       fetchDetails={true}
       renderDescription={row => row.description} // custom description render


### PR DESCRIPTION
KY:
Chalupa-mobile utilizes GooglePlacesAutocomplete for location autocomplete, which currently returns all fields, most of which are unused. This is unnecessary, likely increases latency, and increases cost.

Places fields are are divided into three billing categories: Basic, Contact, and Atmosphere. Basic fields are requested by Chalupa Mobile, billed at base rate, and incur no additional charges. Contact and Atmosphere fields are unused and billed at a higher rate.

Changes:
Passing basic fields through query, ensuring we only request fields in the Basic category, and avoid requesting fields in the Contact and Atmosphere categories.

Reference:
https://developers.google.com/places/web-service/details